### PR TITLE
[i18n] Update de.json säulen - spalten

### DIFF
--- a/translation/de.json
+++ b/translation/de.json
@@ -11,7 +11,7 @@
     "invalidFile": "Ungültige Datei",
     "calendar": "Kalender",
     "zoom": "Zoomen",
-    "columns": "Säulen",
+    "columns": "Spalten",
     "goToNewDomain": "Wir stellen die WeekToDo-Website auf eine neue Domain um und diese wird am 1. April 2022 eingestellt. Um Ihre Daten zu behalten, müssen Sie sie aus dieser Domain exportieren und dann in die neue Domain importieren (aus dem Konfigurationsmenü). Denken Sie daran, dass Sie die Informationen verlieren, die Ihr Browser in dieser Domain speichert, wenn Sie keine Daten migrieren. Wir entschuldigen uns für eventuelle Unannehmlichkeiten.",
     "gotoNewDomainBtn": "Gehen Sie zu einer neuen Domäne",
     "general": "Allgemein",


### PR DESCRIPTION
"Säule" in german describes more like a construction element of a building. Instead it should say "Spalten"

English: "Tables have rows and columns"
German: "Tabellen haben Zeilen und Spalten"

- Source: Native Speaker
- Usage in app: Settings -> Display
![20220722-114228_säulen](https://user-images.githubusercontent.com/4787651/180414136-f7c2b266-14b9-4aeb-b2c9-2ce2062065d1.png)

_Also in the language chooser it should be "Deutsch" instead of "Deutsche", but I could not find that in json_